### PR TITLE
Added POST and PUT support into company controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ env
 staticfiles
 .env
 import.sh
+reset.sh
+test.csv

--- a/api/models/company.py
+++ b/api/models/company.py
@@ -8,8 +8,8 @@ class Company(models.Model):
 
     company_number = models.CharField(
         max_length=8,
-        null=False,
-        blank=False,
+        null=True,
+        blank=True,
         db_index=True,
         verbose_name="Company number")
 

--- a/api/serializers/searchitemserializer.py
+++ b/api/serializers/searchitemserializer.py
@@ -12,6 +12,7 @@ class SearchItemSerializer(serializers.Serializer):
     address_county = serializers.CharField(max_length=160)
     address_country = serializers.CharField(max_length=160)
     address_postcode = serializers.CharField(max_length=20)
+    alt_title = serializers.CharField(max_length=160)
     alt_address_1 = serializers.CharField(max_length=160)
     alt_address_2 = serializers.CharField(max_length=160)
     alt_address_town = serializers.CharField(max_length=160)

--- a/api/services/searchservice.py
+++ b/api/services/searchservice.py
@@ -1,0 +1,150 @@
+from api.models.chcompany import CHCompany
+from api.models.searchitem import SearchItem
+from datahubapi import settings
+
+
+RESULT_SIZE = 10
+
+
+def delete_for_company_number(company_number):
+    # Find the existing entry to get it's id
+    find_query = {
+        "query": {
+            "constant_score": {
+                "filter": {
+                    "term": {
+                        "company_number": company_number
+                    }
+                }
+            }
+        }
+    }
+
+    es_results = settings.ES_CLIENT.search(index=SearchItem.Meta.es_index_name,
+                                           doc_type=SearchItem.Meta.es_type_name,
+                                           body=find_query)
+
+    if es_results['hits']['total'] == 1:
+        index_id = es_results['hits']['hits'][0]['_id']
+        delete_for_id(index_id)
+
+
+def delete_for_company_id(company_id):
+    # Find the existing entry to get it's id
+    find_query = {
+        "query": {
+            "constant_score": {
+                "filter": {
+                    "term": {
+                        "source_id": company_id
+                    }
+                }
+            }
+        }
+    }
+
+    es_results = settings.ES_CLIENT.search(index=SearchItem.Meta.es_index_name,
+                                           doc_type=SearchItem.Meta.es_type_name,
+                                           body=find_query)
+
+    if es_results['hits']['total'] == 1:
+        index_id = es_results['hits']['hits'][0]['_id']
+        delete_for_id(index_id)
+
+
+def delete_for_id(index_id):
+    settings.ES_CLIENT.delete(index=SearchItem.Meta.es_index_name,
+                              doc_type=SearchItem.Meta.es_type_name,
+                              id=index_id,
+                              refresh=True)
+
+
+def search(term, filters=None, page=1):
+
+    if filters is None:
+        filters = {}
+    from_ = (page - 1) * RESULT_SIZE
+
+    query = {
+        "size": RESULT_SIZE,
+        "from": from_,
+        "query": {
+            "query_string": {"query": term},
+        },
+        "aggregations": {
+            "result_type": {
+                "terms": {
+                    "field": "result_type"
+                }
+            }
+        }
+    }
+
+    if len(filters) > 0:
+        query_filters = []
+        for key, value in filters.items():
+            query_filters.append({"term": {key: value}})
+
+        query["filter"] = {
+            "bool": {
+                "must": query_filters
+            }
+        }
+
+    index_name = SearchItem.Meta.es_index_name
+    es_results = settings.ES_CLIENT.search(index=index_name, body=query, )
+    result = transform_search_result(es_result=es_results)
+    return result
+
+
+# Transform an elastic search result into a format that is easier to use
+# and includes the original parameters
+def transform_search_result(es_result):
+    result = {
+        "total": es_result["hits"]["total"],
+        "max_score": es_result["hits"]["max_score"],
+        "hits": es_result["hits"]["hits"],
+    }
+
+    facets = {}
+    aggregations = es_result["aggregations"]
+
+    for aggregation_key, aggregation_value in aggregations.items():
+        facets[aggregation_key] = []
+        for aggregation_bucket in aggregation_value["buckets"]:
+            facets[aggregation_key]\
+                .append({"value": aggregation_bucket["key"], "total": aggregation_bucket["doc_count"]})
+
+    result["facets"] = facets
+    return result
+
+
+# Generate an elastic search item from an company record
+def search_item_from_company(company):
+    ch = CHCompany.objects.get(pk=company.company_number)
+    if company.company_number and len(company.company_number) > 0:
+        result_source = 'COMBINED'
+    else:
+        result_source = 'DIT'
+
+    return SearchItem(
+        source_id=company.id,
+        result_source=result_source,
+        result_type='COMPANY',
+        title=ch.company_name,
+        address_1=ch.registered_address_address_1,
+        address_2=ch.registered_address_address_2,
+        address_town=ch.registered_address_town,
+        address_county=ch.registered_address_county,
+        address_country=ch.registered_address_country,
+        address_postcode=ch.registered_address_postcode,
+        alt_title=company.trading_name,
+        alt_address_1=company.trading_address_1,
+        alt_address_2=company.trading_address_2,
+        alt_address_town=company.trading_address_town,
+        alt_address_county=company.trading_address_county,
+        alt_address_country=company.trading_address_country,
+        alt_address_postcode=company.trading_address_postcode,
+        company_number=company.company_number,
+        incorporation_date=ch.incorporation_date
+    )

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,27 +1,81 @@
 from django.test import TestCase
-from .serializers import CHCompanySerializer, SearchItemSerializer
-from api.models import CHCompany, SearchItem
-import json, requests
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.core.urlresolvers import reverse
+from api.management.commands.load_ch import Command as Loadch
+from api.models.company import Company
+
+from datahubapi import settings
 
 
-class SearchIndexSerializerTests(TestCase):
+class CompanyTests(TestCase):
+    def setUp(self):
+        self.client = APIClient(enforce_csrf_checks=True)
 
-    def x_serialiser(self):
-        search_index = SearchItem(
-            source_id="123",
-            source_type="COMPANY",
-            title="My great company",
-            summary="something that is shown in the search results",
-            postcode="SL4 4QR")
+    def setup_db_and_index(self):
+        load_ch = Loadch()
+        load_ch.handle(filename='test.csv')
 
-        serializer = SearchItemSerializer(search_index)
-        print(serializer.data)
+    # When you save a company, and you include the company number
+    # companies house is the source of truth for that stuff, so
+    # What happens is the frontend sends bare details and we fill in a few from the CH entry
 
-    def test_search(self):
-        data = {
+    def test_post_company_adds_to_db(self):
+        self.setup_db_and_index()
+
+        test_data = dict(
+            company_number='06768809',
+            region='North-West',
+            sectors='Tech'
+        )
+
+        print("URL")
+        print(reverse('company-list'))
+        print("=========================")
+
+        response = self.client.post(reverse('company-list'), test_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED,
+                         'API Response tells the client the object was created')
+
+        self.assertIsNotNone(response.data['id'],
+                             'Confirm that a new ID was returned for the created object')
+
+        # Test that if we save a company and insert CH data into it
+        # for those people not using datahub and still on old CDMS
+        company = Company.objects.get(pk=response.data['id'])
+        self.assertEqual(company.registered_name, 'CORPORATE UMBRELLA LIMITED')
+        self.assertEqual(company.company_number, '06768809')
+        self.assertEqual(company.business_type, 'Private Limited Company')
+        self.assertEqual(company.region, 'North-West')
+        self.assertEqual(company.sectors, 'Tech')
+
+    def test_post_company_updates_existing_ch_index_record(self):
+        self.setup_db_and_index()
+
+        test_data = dict(
+            company_number='06768809',
+            region='North-West',
+            sectors='Tech',
+            trading_name='Freds'
+        )
+
+        response = self.client.post(reverse('company-list'), test_data, format='json')
+
+        query = {
             "query": {
-                "query_string": {"query": "breathe"}
-            }
+                "query_string": {"query": test_data["company_number"]},
+            },
         }
-        response = requests.post('http://127.0.0.1:9200/datahub/_search', data=json.dumps(data))
-        print(response.json())
+
+        es_results = settings.ES_CLIENT.search(index='datahub', body=query)
+
+        self.assertEqual(es_results['hits']['total'], 1)
+
+        hit = es_results['hits']['hits'][0]['_source']
+
+        self.assertEqual(hit['result_type'], 'COMBINED')
+        self.assertEqual(hit['source_id'], response.data['id'])
+        self.assertEqual(hit['company_number'], '06768809')
+        self.assertEqual(hit['title'], 'CORPORATE UMBRELLA LIMITED')
+        self.assertEqual(hit['alt_title'], 'Freds')

--- a/api/views/chcompanyviewset.py
+++ b/api/views/chcompanyviewset.py
@@ -1,5 +1,4 @@
 from rest_framework import viewsets
-
 from api.models.chcompany import CHCompany
 from api.serializers import CHCompanySerializer
 

--- a/api/views/companyviewset.py
+++ b/api/views/companyviewset.py
@@ -1,9 +1,19 @@
-from rest_framework import viewsets
-from rest_framework import status
-from api.models.company import Company
-from api.models.searchitem import search_item_from_company
-from api.serializers import CompanySerializer
+from rest_framework import viewsets, status
 from rest_framework.response import Response
+from api.models.chcompany import CHCompany
+from api.models.company import Company
+from api.serializers import CompanySerializer
+from api.services.searchservice import delete_for_company_number, delete_for_company_id, search_item_from_company
+
+
+def check_ch_data(request):
+    # look at the incoming data. Is there a company number?
+    # if so then lookup some CH data and add it here before turning it
+    # into a company.
+    if request.data['company_number'] and len(request.data['company_number']) > 0:
+        ch = CHCompany.objects.get(pk=request.data['company_number'])
+        request.data['registered_name'] = ch.company_name
+        request.data['business_type'] = ch.company_category
 
 
 class CompanyViewSet(viewsets.ModelViewSet):
@@ -11,10 +21,34 @@ class CompanyViewSet(viewsets.ModelViewSet):
     serializer_class = CompanySerializer
 
     def create(self, request, **kwargs):
+        check_ch_data(request)
+
+        # Create a company, validate and save
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         new_company = serializer.save()
+
+        # Delete the existing index entry and create a new one.
+        if request.data['company_number'] and len(request.data['company_number']) > 0:
+            delete_for_company_number(new_company.company_number)
+
         search_item = search_item_from_company(new_company)
-        search_item.add()
-        headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+        search_item.save()
+
+        # send back the newly company record and inform the user if all is well.
+        response_serializer = self.get_serializer(new_company)
+        headers = self.get_success_headers(response_serializer.data)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def update(self, request, *args, **kwargs):
+        check_ch_data(request)
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        company = serializer.save()
+        delete_for_company_id(company.id)
+        search_item = search_item_from_company(company)
+        search_item.save()
+
+        return Response(serializer.data)

--- a/api/views/searchview.py
+++ b/api/views/searchview.py
@@ -1,67 +1,9 @@
 import json
 from django.http import HttpResponse
-from api.models.searchitem import SearchItem
-from datahubapi import settings
-
-SIZE = 10
+from api.services.searchservice import search as es_search
 
 
-def transform_search_result(es_result):
-    result = {
-        "total": es_result["hits"]["total"],
-        "max_score": es_result["hits"]["max_score"],
-        "hits": es_result["hits"]["hits"],
-    }
-
-    facets = {}
-    aggregations = es_result["aggregations"]
-
-    for aggregation_key, aggregation_value in aggregations.items():
-        facets[aggregation_key] = []
-        for aggregation_bucket in aggregation_value["buckets"]:
-            facets[aggregation_key].append({"value": aggregation_bucket["key"], "total": aggregation_bucket["doc_count"]})
-
-    result["facets"] = facets
-    return result
-
-
-def es_search(term, filters={}, page=1):
-
-    from_ = (page - 1) * SIZE
-
-    query = {
-        "size": SIZE,
-        "from": from_,
-        "query": {
-            "query_string": {"query": term},
-        },
-        "aggregations": {
-            "result_type": {
-                "terms": {
-                    "field": "result_type"
-                }
-            }
-        }
-    }
-
-    if len(filters) > 0:
-        query_filters = []
-        for key, value in filters.items():
-            query_filters.append({"term": {key: value}})
-
-        query["filter"] = {
-            "bool": {
-                "must": query_filters
-            }
-        }
-
-    index_name = SearchItem.Meta.es_index_name
-    es_results = settings.ES_CLIENT.search(index=index_name, body=query, )
-    result = transform_search_result(es_result=es_results)
-    return result
-
-
-def parsefilters(filters):
+def parse_filters(filters):
     parsed_filters = {}
     for filter_item in filters:
         split = filter_item.split(":")
@@ -74,7 +16,7 @@ def parsefilters(filters):
 def search(request):
     params = {
         "term": request.GET.get('term', ''),
-        "filters": parsefilters(request.GET.getlist('filter')),
+        "filters": parse_filters(request.GET.getlist('filter')),
         "page": int(request.GET.get('page', '1')),
     }
 


### PR DESCRIPTION
And Company endpoint allows the addition of DIT data to a companies house entry.

When a user creates a new company it populates some fields from the CH record associated with it and saves that to the DB. The method also removes the CH record from the search index and replaces it with a combined record.

PUT allows you to update a Company record and will update the search index as well as the DB